### PR TITLE
no such thing as 1830A, and the 1830 is 43602

### DIFF
--- a/types-of-wireless-card/m2.md
+++ b/types-of-wireless-card/m2.md
@@ -12,8 +12,8 @@ Do your research to see what slot your hardware has(and don't mix up E key with 
 ![](https://i.imgur.com/jBP1D3t.jpg)
 
 
-* **BCM94360**:
-   * Dell DW1830A (A+E Key, quite wide so make sure your laptop has room)
+* **BCM943602**:
+   * Dell DW1830 (A+E Key, quite wide so make sure your laptop has room)
 * **BCM94350ZAE**:
    * Lenovo Foxconn T77H649(A+E Key)
    * Lite-On WCBN808B(A+E Key)


### PR DESCRIPTION
Based off [WikiDevi](https://wikidevi.com/wiki/Dell_Wireless_1830_(DW1830)) and [OSXLatitude](https://osxlatitude.com/forums/topic/11138-inventory-of-supportedunsupported-wireless-cards-2-sierra-catalina/), there does seem to be a difference between 4360 and 43602